### PR TITLE
added default permission for all S3 folders - fullControl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.upplication</groupId>
 	<artifactId>s3fs</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.6</version>
+	<version>3.0.7</version>
 	<name>s3fs</name>
 	<description>S3 filesystem provider for Java 7</description>
 	<url>https://github.com/Upplication/Amazon-S3-FileSystem-NIO2</url>

--- a/src/main/java/com/upplication/s3fs/util/S3Utils.java
+++ b/src/main/java/com/upplication/s3fs/util/S3Utils.java
@@ -105,6 +105,9 @@ public class S3Utils {
             userPrincipal = new S3UserPrincipal(owner.getId() + ":" + owner.getDisplayName());
             permissions = toPosixFilePermissions(acl.getGrantsAsList());
         }
+        else {
+            permissions =  toPosixFilePermission(Permission.FullControl);
+        }
 
         return new S3PosixFileAttributes((String)attrs.fileKey(), attrs.lastModifiedTime(),
                 attrs.size(), attrs.isDirectory(), attrs.isRegularFile(), userPrincipal, null, permissions);

--- a/src/main/java/com/upplication/s3fs/util/S3Utils.java
+++ b/src/main/java/com/upplication/s3fs/util/S3Utils.java
@@ -104,8 +104,7 @@ public class S3Utils {
 
             userPrincipal = new S3UserPrincipal(owner.getId() + ":" + owner.getDisplayName());
             permissions = toPosixFilePermissions(acl.getGrantsAsList());
-        }
-        else {
+        } else {
             permissions =  toPosixFilePermission(Permission.FullControl);
         }
 


### PR DESCRIPTION
There is a problem with bash sftp client with "cd" command, because for S3 folder permission flag was null, and it fails during permission check on the client side.
Default permission added to navigate to subfolders from the ftp root.